### PR TITLE
be able to read both spike_clusters.npy or spikes.clusters.npy 

### DIFF
--- a/calc_CellMetrics/loadSpikes.m
+++ b/calc_CellMetrics/loadSpikes.m
@@ -461,7 +461,7 @@ if parameters.forceReload
             end
             disp('loadSpikes: Loading Phy data')
             labelsToRead = {'good'};
-            spike_cluster_index = readNPY(fullfile(clusteringpath_full, 'spike_clusters.npy'));
+            spike_cluster_index = readNPY(fullfile(clusteringpath_full, 'spike*clusters.npy'));
             spike_times = readNPY(fullfile(clusteringpath_full, 'spike_times.npy'));
             spike_amplitudes = readNPY(fullfile(clusteringpath_full, 'amplitudes.npy'));
             spike_clusters = unique(spike_cluster_index);

--- a/calc_CellMetrics/loadSpikes.m
+++ b/calc_CellMetrics/loadSpikes.m
@@ -462,7 +462,7 @@ if parameters.forceReload
             disp('loadSpikes: Loading Phy data')
             labelsToRead = {'good'};
             spike_cluster_index = readNPY(fullfile(clusteringpath_full, 'spike*clusters.npy'));
-            spike_times = readNPY(fullfile(clusteringpath_full, 'spike_times.npy'));
+            spike_times = readNPY(fullfile(clusteringpath_full, 'spike*times.npy'));
             spike_amplitudes = readNPY(fullfile(clusteringpath_full, 'amplitudes.npy'));
             spike_clusters = unique(spike_cluster_index);
             filename1 = fullfile(clusteringpath_full,'cluster_group.tsv');

--- a/toolboxes/npy-matlb/readNPY.m
+++ b/toolboxes/npy-matlb/readNPY.m
@@ -6,6 +6,8 @@ function data = readNPY(filename)
 % See https://github.com/kwikteam/npy-matlab/blob/master/npy.ipynb for
 % more. 
 %
+f=dir(filename);
+filename=f.name;
 
 [shape, dataType, fortranOrder, littleEndian, totalHeaderLength, ~] = readNPYheader(filename);
 

--- a/toolboxes/npy-matlb/readNPYheader.m
+++ b/toolboxes/npy-matlb/readNPYheader.m
@@ -8,7 +8,8 @@ function [arrayShape, dataType, fortranOrder, littleEndian, totalHeaderLength, n
 % therein.
 %
 % Based on spec at http://docs.scipy.org/doc/numpy-dev/neps/npy-format.html
-
+f=dir(filename);
+filename=f.name;
 fid = fopen(filename);
 
 % verify that the file exists

--- a/toolboxes/npy-matlb/readNPYheader.m
+++ b/toolboxes/npy-matlb/readNPYheader.m
@@ -8,8 +8,6 @@ function [arrayShape, dataType, fortranOrder, littleEndian, totalHeaderLength, n
 % therein.
 %
 % Based on spec at http://docs.scipy.org/doc/numpy-dev/neps/npy-format.html
-f=dir(filename);
-filename=f.name;
 fid = fopen(filename);
 
 % verify that the file exists


### PR DESCRIPTION
older Phy versions have spikes.Clusters.npy, phy2 has spike_clusters.npy; e.g. Steinmetz data has been processed with the older version.  just a minor edit to be able to read both names