### PR TITLE
add strain value for Human-TumorCase species

### DIFF
--- a/calc_CellMetrics/gui_session.m
+++ b/calc_CellMetrics/gui_session.m
@@ -37,7 +37,7 @@ UI.list.sortingFormat = {'Phy','KiloSort','SpyKING CIRCUS','Klustakwik','KlustaV
 UI.list.inputsType = {'adc','aux','dat','dig'}; % input data types
 UI.list.sessionTypes = {'Acute','Chronic','Unknown'}; % session types
 UI.list.species = {'Unknown','Rat', 'Mouse','Red-eared Turtles'}; % animal species
-UI.list.strain = {'Unknown','C57B1/6','B6/FVB Hybrid','BALB/cJ','Red-eared slider','DBA2/J','Brown Norway','Fischer 344','Long Evans','Sprague Dawleys','Wistar'}; % animal strains
+UI.list.strain = {'Unknown','C57B1/6','B6/FVB Hybrid','BALB/cJ','Red-eared slider','DBA2/J','Brown Norway','Fischer 344','Long Evans','Sprague Dawleys','Wistar','NA'}; % animal strains
 UI.list.strain_species = {'Unknown','Mouse','Mouse','Mouse','Red-eared Turtles','Mouse','Rat','Rat','Rat','Rat','Rat'}; % animal strains parent in species
 
 % metrics in cell metrics pipeline


### PR DESCRIPTION
the 'strain' list didn't have a value associated with the "human_tumorCase" entry in 'species' list; causing an error when function 'updateStrain' is run (i.e. line 1045 of gui_session.m) 