### PR TITLE
fixed possible bug in loadSpikes.m related to AnatGrps

### DIFF
--- a/calc_CellMetrics/loadSpikes.m
+++ b/calc_CellMetrics/loadSpikes.m
@@ -855,9 +855,10 @@ if exist(fullfile(session.general.basePath,[session.general.name,'.sessionInfo.m
         warning('No spike groups exist in the xml. Anatomical groups used instead')
         session.extracellular.nSpikeGroups = size(sessionInfo.AnatGrps,2); % Number of spike groups
         session.extracellular.spikeGroups.channels = {sessionInfo.AnatGrps.Channels}; % Spike groups
+   
+        session.extracellular.nElectrodeGroups = size(sessionInfo.AnatGrps,2); % Number of electrode groups
+        session.extracellular.electrodeGroups.channels = {sessionInfo.AnatGrps.Channels}; % Electrode groups
     end
-    session.extracellular.nElectrodeGroups = size(sessionInfo.AnatGrps,2); % Number of electrode groups
-    session.extracellular.electrodeGroups.channels = {sessionInfo.AnatGrps.Channels}; % Electrode groups
     session.extracellular.sr = sessionInfo.rates.wideband; % Sampling rate of dat file
     session.extracellular.srLfp = sessionInfo.rates.lfp; % Sampling rate of lfp file
     session.extracellular.nChannels = sessionInfo.nChannels; % Number of channels
@@ -877,9 +878,10 @@ elseif exist('LoadXml.m','file') && exist(fullfile(session.general.basePath,[ses
         warning('No spike groups exist in the xml. Anatomical groups used instead')
         session.extracellular.nSpikeGroups = size(sessionInfo.AnatGrps,2); % Number of spike groups
         session.extracellular.spikeGroups.channels = {sessionInfo.AnatGrps.Channels}; % Spike groups
+    
+        session.extracellular.nElectrodeGroups = size(sessionInfo.AnatGrps,2); % Number of electrode groups
+        session.extracellular.electrodeGroups.channels = {sessionInfo.AnatGrps.Channels}; % Electrode groups
     end
-    session.extracellular.nElectrodeGroups = size(sessionInfo.AnatGrps,2); % Number of electrode groups
-    session.extracellular.electrodeGroups.channels = {sessionInfo.AnatGrps.Channels}; % Electrode groups
     session.extracellular.sr = sessionInfo.SampleRate; % Sampling rate of dat file
     session.extracellular.srLfp = sessionInfo.lfpSampleRate; % Sampling rate of lfp file
     session.extracellular.nChannels = sessionInfo.nChannels; % Number of channels


### PR DESCRIPTION
This is my first pull request, so I hope I am getting this right.. 
I just installed CellExplorer (on a trial Matlab license with all Toolboxes), and was working trough the tutorial with our data. To fix an error msg (Reference to non-existent field 'AnatGrps') I made a small change to the function loadSpikes.m